### PR TITLE
feat: new SVG logo suite with Invicti palette

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-![kntrl logo](./docs/img/kntrl_logo.png) <!-- markdownlint-disable-line first-line-heading -->
+![kntrl logo](./docs/img/kntrl_logo_dark.svg) <!-- markdownlint-disable-line first-line-heading -->
 
 `kntrl` is an eBPF-based runtime security agent that monitors and controls network, process, DNS, TLS, and file activity on CI/CD runners and build pipelines. It hooks into kernel-level syscalls to enforce policies in real time — blocking supply-chain attacks, unauthorized network access, and anomalous process behaviour before they cause damage.
 

--- a/docs/img/kntrl_icon.svg
+++ b/docs/img/kntrl_icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 110" fill="none">
+  <!-- kntrl icon – standalone mark (dark bg) -->
+
+  <!-- Shield body -->
+  <path d="M55 8L16 24v32c0 30 39 52 39 52s39-22 39-52V24L55 8z"
+        fill="#101820" />
+
+  <!-- Inner shield highlight -->
+  <path d="M55 16L26 28v26c0 24 29 42 29 42s29-18 29-42V28L55 16z"
+        fill="#1a2a35" />
+
+  <!-- eBPF kernel pulse -->
+  <polyline points="28,58 38,58 43,42 48,70 53,50 58,62 63,54 68,58 82,58"
+            stroke="#4BD783" stroke-width="3.5" fill="none"
+            stroke-linecap="round" stroke-linejoin="round" />
+
+  <!-- Center dot -->
+  <circle cx="55" cy="58" r="3.5" fill="#4BD783" />
+
+  <!-- Top shield accent -->
+  <path d="M55 8L16 24v4L55 12l39 16v-4L55 8z"
+        fill="#4BD783" opacity="0.6" />
+</svg>

--- a/docs/img/kntrl_icon_green.svg
+++ b/docs/img/kntrl_icon_green.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 110" fill="none">
+  <!-- kntrl icon – green shield variant -->
+
+  <!-- Shield body -->
+  <path d="M55 8L16 24v32c0 30 39 52 39 52s39-22 39-52V24L55 8z"
+        fill="#4BD783" />
+
+  <!-- Inner shield -->
+  <path d="M55 16L26 28v26c0 24 29 42 29 42s29-18 29-42V28L55 16z"
+        fill="#3bc272" />
+
+  <!-- eBPF kernel pulse -->
+  <polyline points="28,58 38,58 43,42 48,70 53,50 58,62 63,54 68,58 82,58"
+            stroke="#101820" stroke-width="3.5" fill="none"
+            stroke-linecap="round" stroke-linejoin="round" />
+
+  <!-- Center dot -->
+  <circle cx="55" cy="58" r="3.5" fill="#101820" />
+
+  <!-- Top shield accent -->
+  <path d="M55 8L16 24v4L55 12l39 16v-4L55 8z"
+        fill="#ffffff" opacity="0.3" />
+</svg>

--- a/docs/img/kntrl_logo_dark.svg
+++ b/docs/img/kntrl_logo_dark.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 120" fill="none">
+  <!-- kntrl logo – dark variant (for light backgrounds) -->
+
+  <!-- Shield icon with eBPF kernel pulse -->
+  <g transform="translate(10, 5)">
+    <!-- Outer shield -->
+    <path d="M55 8L20 22v30c0 28 35 48 35 48s35-20 35-48V22L55 8z"
+          fill="#101820" opacity="0.08" />
+    <path d="M55 4L16 20v32c0 30 39 52 39 52s39-22 39-52V20L55 4z"
+          stroke="#101820" stroke-width="3.5" fill="none" stroke-linejoin="round" />
+
+    <!-- Inner shield glow -->
+    <path d="M55 14L26 26v26c0 24 29 42 29 42s29-18 29-42V26L55 14z"
+          fill="#4BD783" opacity="0.12" />
+
+    <!-- eBPF kernel pulse line -->
+    <polyline points="30,56 40,56 45,40 50,68 55,48 60,60 65,52 70,56 80,56"
+              stroke="#4BD783" stroke-width="3" fill="none"
+              stroke-linecap="round" stroke-linejoin="round" />
+
+    <!-- Center dot -->
+    <circle cx="55" cy="56" r="3" fill="#4BD783" />
+  </g>
+
+  <!-- Wordmark: kntrl -->
+  <g transform="translate(130, 28)">
+    <!-- k -->
+    <path d="M0 0v64h10V38l22 26h14L22 34 44 8H30L10 32V0H0z"
+          fill="#101820" />
+    <!-- n -->
+    <path d="M56 8v56h10V34c0-10 8-18 18-18s18 8 18 18v30h10V32c0-16-12-28-28-28c-8 0-16 4-20 12V8H56z"
+          fill="#101820" />
+    <!-- t -->
+    <path d="M130 0v8h-8v10h8v30c0 10 6 16 16 16h6V54h-6c-4 0-6-2-6-6V18h12V8h-12V0H130z"
+          fill="#101820" />
+    <!-- r -->
+    <path d="M172 8v56h10V32c0-10 6-16 16-16h2V6h-2c-8 0-14 4-16 10V8H172z"
+          fill="#101820" />
+    <!-- l -->
+    <path d="M216 0v64h10V0H216z"
+          fill="#101820" />
+  </g>
+
+  <!-- Accent bar -->
+  <rect x="130" y="96" width="96" height="3" rx="1.5" fill="#4BD783" />
+</svg>

--- a/docs/img/kntrl_logo_light.svg
+++ b/docs/img/kntrl_logo_light.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 120" fill="none">
+  <!-- kntrl logo – light variant (for dark backgrounds) -->
+
+  <!-- Shield icon with eBPF kernel pulse -->
+  <g transform="translate(10, 5)">
+    <!-- Outer shield -->
+    <path d="M55 8L20 22v30c0 28 35 48 35 48s35-20 35-48V22L55 8z"
+          fill="#4BD783" opacity="0.08" />
+    <path d="M55 4L16 20v32c0 30 39 52 39 52s39-22 39-52V20L55 4z"
+          stroke="#ffffff" stroke-width="3.5" fill="none" stroke-linejoin="round" />
+
+    <!-- Inner shield glow -->
+    <path d="M55 14L26 26v26c0 24 29 42 29 42s29-18 29-42V26L55 14z"
+          fill="#4BD783" opacity="0.15" />
+
+    <!-- eBPF kernel pulse line -->
+    <polyline points="30,56 40,56 45,40 50,68 55,48 60,60 65,52 70,56 80,56"
+              stroke="#4BD783" stroke-width="3" fill="none"
+              stroke-linecap="round" stroke-linejoin="round" />
+
+    <!-- Center dot -->
+    <circle cx="55" cy="56" r="3" fill="#4BD783" />
+  </g>
+
+  <!-- Wordmark: kntrl -->
+  <g transform="translate(130, 28)">
+    <!-- k -->
+    <path d="M0 0v64h10V38l22 26h14L22 34 44 8H30L10 32V0H0z"
+          fill="#ffffff" />
+    <!-- n -->
+    <path d="M56 8v56h10V34c0-10 8-18 18-18s18 8 18 18v30h10V32c0-16-12-28-28-28c-8 0-16 4-20 12V8H56z"
+          fill="#ffffff" />
+    <!-- t -->
+    <path d="M130 0v8h-8v10h8v30c0 10 6 16 16 16h6V54h-6c-4 0-6-2-6-6V18h12V8h-12V0H130z"
+          fill="#ffffff" />
+    <!-- r -->
+    <path d="M172 8v56h10V32c0-10 6-16 16-16h2V6h-2c-8 0-14 4-16 10V8H172z"
+          fill="#ffffff" />
+    <!-- l -->
+    <path d="M216 0v64h10V0H216z"
+          fill="#ffffff" />
+  </g>
+
+  <!-- Accent bar -->
+  <rect x="130" y="96" width="96" height="3" rx="1.5" fill="#4BD783" />
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>kntrl - eBPF Runtime Security for CI/CD Pipelines</title>
     <meta name="description" content="Open-source eBPF-powered runtime security agent that monitors and prevents supply chain attacks in CI/CD pipelines in real-time.">
-    <link rel="icon" type="image/png" href="img/kntrl_logo.png">
+    <link rel="icon" type="image/svg+xml" href="img/kntrl_icon_green.svg">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -460,7 +460,7 @@
 <nav>
     <div class="nav-inner">
         <a href="#" class="nav-logo">
-            <img src="img/kntrl_logo.png" alt="kntrl">
+            <img src="img/kntrl_icon_green.svg" alt="kntrl">
             kntrl
         </a>
         <div class="nav-links">
@@ -857,7 +857,7 @@
     <div class="container">
         <div class="footer-inner">
             <div class="footer-left">
-                <img src="img/kntrl_logo.png" alt="kntrl">
+                <img src="img/kntrl_logo_light.svg" alt="kntrl" style="height:28px;width:auto;">
                 <span>kntrl &mdash; Open source, Apache 2.0 License</span>
             </div>
             <div class="footer-links">


### PR DESCRIPTION
## Summary
- New SVG logo with shield + eBPF kernel pulse design in 4 variants (dark/light full logos, dark/green standalone icons)
- Updated `index.html` and `Readme.md` to use new SVG logos instead of old PNG
- Uses Invicti color palette (#101820 dark, #4BD783 green)

## Test plan
- [ ] Verify logos render correctly on GitHub README
- [ ] Verify landing page favicon and nav logo display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)