### PR TITLE
fix: switch trace_fork to tp_btf for cross-kernel CO-RE compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [v0.2.1] - 2026-04-01
+
+### Fixed
+- **trace_fork CO-RE relocation failure on kernel 6.17+**: Switched `trace_fork` from
+  `tracepoint/sched/sched_process_fork` to `tp_btf/sched_process_fork`. The old approach
+  accessed fields on `struct trace_event_raw_sched_process_fork`, which is often absent
+  from the target kernel's BTF, causing libbpf to emit poison value `0xBAD2310` and fail
+  program loading. The new approach uses BTF-enabled raw tracepoints with `BPF_PROG` macro,
+  receiving `struct task_struct *parent, *child` directly — these are always present in
+  kernel BTF and CO-RE relocations resolve reliably across all kernels 5.5+.
+
+## [v0.2.0] - 2026-03-28
+
+### Added
+- Modular eBPF sensor architecture (network, process, DNS, file, SNI, cgroup)
+- Process execution blocking and file write protection
+- Cloud upload via NATS streaming
+- OPA policy engine with hot-reload (SIGHUP)
+- GitHub Action integration (`kntrl-action`)
+- SVG logo suite with Invicti palette

--- a/bpf/sensor_process.h
+++ b/bpf/sensor_process.h
@@ -83,8 +83,8 @@ int trace_exec(struct trace_event_raw_sched_process_exec *ctx) {
 	return 0;
 }
 
-SEC("tracepoint/sched/sched_process_fork")
-int trace_fork(struct trace_event_raw_sched_process_fork *ctx) {
+SEC("tp_btf/sched_process_fork")
+int BPF_PROG(trace_fork, struct task_struct *parent, struct task_struct *child) {
 	__u32 key = 0;
 	__u32 *enabled = bpf_map_lookup_elem(&process_monitor_map, &key);
 	if (!enabled || *enabled == 0)
@@ -103,11 +103,11 @@ int trace_fork(struct trace_event_raw_sched_process_fork *ctx) {
 		return 0;
 
 	evt->ts_us = bpf_ktime_get_ns() / 1000;
-	evt->pid = ctx->child_pid;
-	evt->ppid = bpf_get_current_pid_tgid() >> 32;
+	evt->pid = BPF_CORE_READ(child, tgid);
+	evt->ppid = BPF_CORE_READ(parent, tgid);
 	evt->event_type = EVENT_TYPE_FORK;
 
-	bpf_probe_read_str(&evt->comm, TASK_COMM_LEN, ctx->child_comm);
+	BPF_CORE_READ_STR_INTO(&evt->comm, child, comm);
 	evt->filename[0] = '\0';
 	evt->args[0] = '\0';
 	evt->args_len = 0;

--- a/bpf/sensor_process.h
+++ b/bpf/sensor_process.h
@@ -107,7 +107,7 @@ int trace_fork(struct trace_event_raw_sched_process_fork *ctx) {
 	evt->ppid = bpf_get_current_pid_tgid() >> 32;
 	evt->event_type = EVENT_TYPE_FORK;
 
-	BPF_CORE_READ_STR_INTO(&evt->comm, ctx, child_comm);
+	bpf_probe_read_kernel_str(&evt->comm, TASK_COMM_LEN, ctx->child_comm);
 	evt->filename[0] = '\0';
 	evt->args[0] = '\0';
 	evt->args_len = 0;

--- a/bpf/sensor_process.h
+++ b/bpf/sensor_process.h
@@ -103,11 +103,11 @@ int trace_fork(struct trace_event_raw_sched_process_fork *ctx) {
 		return 0;
 
 	evt->ts_us = bpf_ktime_get_ns() / 1000;
-	evt->pid = BPF_CORE_READ(ctx, child_pid);
+	evt->pid = ctx->child_pid;
 	evt->ppid = bpf_get_current_pid_tgid() >> 32;
 	evt->event_type = EVENT_TYPE_FORK;
 
-	bpf_probe_read_kernel_str(&evt->comm, TASK_COMM_LEN, ctx->child_comm);
+	bpf_probe_read_str(&evt->comm, TASK_COMM_LEN, ctx->child_comm);
 	evt->filename[0] = '\0';
 	evt->args[0] = '\0';
 	evt->args_len = 0;

--- a/bpf/sensor_process.h
+++ b/bpf/sensor_process.h
@@ -107,7 +107,7 @@ int trace_fork(struct trace_event_raw_sched_process_fork *ctx) {
 	evt->ppid = bpf_get_current_pid_tgid() >> 32;
 	evt->event_type = EVENT_TYPE_FORK;
 
-	bpf_probe_read_str(&evt->comm, TASK_COMM_LEN, ctx->child_comm);
+	BPF_CORE_READ_STR_INTO(&evt->comm, ctx, child_comm);
 	evt->filename[0] = '\0';
 	evt->args[0] = '\0';
 	evt->args_len = 0;

--- a/docs/img/logo_preview.html
+++ b/docs/img/logo_preview.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  body { font-family: system-ui; margin: 40px; }
+  .row { display: flex; gap: 40px; margin-bottom: 40px; align-items: center; }
+  .card { padding: 30px; border-radius: 12px; }
+  .light { background: #ffffff; border: 1px solid #ddd; }
+  .dark { background: #101820; }
+  h2 { margin-top: 40px; color: #333; }
+  img { display: block; }
+  .label { font-size: 12px; color: #888; margin-top: 8px; }
+</style>
+</head>
+<body>
+<h1>kntrl Logo Suite</h1>
+
+<h2>Full Logo (icon + wordmark)</h2>
+<div class="row">
+  <div class="card light">
+    <img src="kntrl_logo_dark.svg" height="80">
+    <div class="label">Dark variant (light bg)</div>
+  </div>
+  <div class="card dark">
+    <img src="kntrl_logo_light.svg" height="80">
+    <div class="label" style="color:#666">Light variant (dark bg)</div>
+  </div>
+</div>
+
+<h2>Icon Only</h2>
+<div class="row">
+  <div class="card light">
+    <img src="kntrl_icon.svg" height="80">
+    <div class="label">Dark shield</div>
+  </div>
+  <div class="card dark">
+    <img src="kntrl_icon.svg" height="80">
+    <div class="label" style="color:#666">Dark shield (on dark bg)</div>
+  </div>
+  <div class="card light">
+    <img src="kntrl_icon_green.svg" height="80">
+    <div class="label">Green shield</div>
+  </div>
+  <div class="card dark">
+    <img src="kntrl_icon_green.svg" height="80">
+    <div class="label" style="color:#666">Green shield (on dark bg)</div>
+  </div>
+</div>
+
+<h2>Small sizes</h2>
+<div class="row">
+  <div class="card dark" style="padding:15px">
+    <img src="kntrl_icon.svg" height="32">
+    <div class="label" style="color:#666">32px</div>
+  </div>
+  <div class="card dark" style="padding:15px">
+    <img src="kntrl_icon_green.svg" height="32">
+    <div class="label" style="color:#666">32px</div>
+  </div>
+  <div class="card dark" style="padding:15px">
+    <img src="kntrl_icon.svg" height="16">
+    <div class="label" style="color:#666">16px favicon</div>
+  </div>
+  <div class="card dark" style="padding:15px">
+    <img src="kntrl_icon_green.svg" height="16">
+    <div class="label" style="color:#666">16px favicon</div>
+  </div>
+</div>
+
+<h2>Comparison with original</h2>
+<div class="row">
+  <div class="card light">
+    <img src="kntrl_logo.png" height="60">
+    <div class="label">Original (PNG)</div>
+  </div>
+  <div class="card light">
+    <img src="kntrl_logo_dark.svg" height="60">
+    <div class="label">New dark variant</div>
+  </div>
+</div>
+</body>
+</html>

--- a/internal/handlers/tracer/tracer.go
+++ b/internal/handlers/tracer/tracer.go
@@ -66,7 +66,6 @@ const (
 var tracePointAttach = map[string][2]string{
 	"inet_sock_set_state": {"sock", "inet_sock_set_state"},
 	"trace_exec":          {"sched", "sched_process_exec"},
-	"trace_fork":          {"sched", "sched_process_fork"},
 	"trace_openat":        {"syscalls", "sys_enter_openat"},
 	"trace_renameat2":     {"syscalls", "sys_enter_renameat2"},
 	"trace_unlinkat":      {"syscalls", "sys_enter_unlinkat"},


### PR DESCRIPTION
## Summary

- Switch `trace_fork` from `tracepoint/sched/sched_process_fork` to `tp_btf/sched_process_fork` using `BPF_PROG` macro
- Read child PID/comm from `struct task_struct` via `BPF_CORE_READ` instead of tracepoint format struct fields
- Remove `trace_fork` from `tracePointAttach` map (now auto-attaches as `Tracing` type)
- Add CHANGELOG.md

## Root Cause

`struct trace_event_raw_sched_process_fork` is often absent from the target kernel's BTF (notably on kernel 6.17-azure), causing libbpf CO-RE relocations to fail with poison value `0xBAD2310`.

## Fix

`tp_btf` (BTF-enabled raw tracepoint) receives `struct task_struct *parent, *child` directly — these types are always present in kernel BTF, so CO-RE works reliably across all kernels 5.5+.

## Test plan

- [x] Docker build passes (`go generate` + `go build`)
- [ ] Merge and rebuild v0.2.1 release binary
- [ ] Verify on GitHub Actions runner (kernel 6.17-azure) via kntrl-action-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)