### PR TITLE
fix: improve observability on self-hosted runners

### DIFF
--- a/cmd/cli/status.go
+++ b/cmd/cli/status.go
@@ -33,11 +33,10 @@ func initStatusCommand() *cobra.Command {
 			}
 
 			if err := process.Signal(syscall.Signal(0)); err != nil {
-				qwm(127, "kntrl is not running!")
-
-				if err := os.Remove(pidfile); err != nil {
-					qwe(127, err, "failed to remove pidfile")
+				if rmErr := os.Remove(pidfile); rmErr != nil {
+					qwe(127, rmErr, "failed to remove pidfile")
 				}
+				qwm(127, "kntrl is not running!")
 			}
 
 			qwm(0, "Running with PID: "+strconv.Itoa(pid))

--- a/cmd/cli/tracer.go
+++ b/cmd/cli/tracer.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -10,7 +11,10 @@ import (
 	"github.com/kondukto-io/kntrl/internal/handlers/tracer"
 )
 
-const pidfile = "/var/run/kntrl.pid"
+const (
+	pidfile = "/var/run/kntrl.pid"
+	logfile = "/var/log/kntrl.log"
+)
 
 var daemon = false
 
@@ -66,9 +70,15 @@ func daemonize(args []string) error {
 		filteredArgs = append(filteredArgs, args[i])
 	}
 
+	logFile, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open daemon log file %s: %w", logfile, err)
+	}
+	defer logFile.Close()
+
 	cmd := exec.Command(os.Args[0], filteredArgs...)
-	cmd.Stdout = nil
-	cmd.Stderr = nil
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
 	cmd.Stdin = nil
 
 	if err := cmd.Start(); err != nil {
@@ -76,7 +86,7 @@ func daemonize(args []string) error {
 	}
 
 	savePID(cmd.Process.Pid)
-	qwm(0, "Process started with PID: "+strconv.Itoa(cmd.Process.Pid))
+	qwm(0, fmt.Sprintf("Process started with PID: %d (logs: %s)", cmd.Process.Pid, logfile))
 
 	return nil
 }

--- a/cmd/cli/tracer.go
+++ b/cmd/cli/tracer.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -14,6 +16,14 @@ import (
 const (
 	pidfile = "/var/run/kntrl.pid"
 	logfile = "/var/log/kntrl.log"
+
+	// readyEnv names the environment variable used to pass the readiness
+	// pipe file descriptor from the parent daemoniser to the child tracer.
+	readyEnv = "KNTRL_READY_FD"
+
+	// readyTimeout bounds how long the parent waits for the child to
+	// signal that the eBPF programs have been attached successfully.
+	readyTimeout = 15 * time.Second
 )
 
 var daemon = false
@@ -76,19 +86,65 @@ func daemonize(args []string) error {
 	}
 	defer logFile.Close()
 
+	// readiness pipe: the child writes a single byte once eBPF programs
+	// are attached
+	readyR, readyW, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("failed to create readiness pipe: %w", err)
+	}
+	defer readyR.Close()
+
 	cmd := exec.Command(os.Args[0], filteredArgs...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
+	cmd.ExtraFiles = []*os.File{readyW}
+	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=3", readyEnv))
 
 	if err := cmd.Start(); err != nil {
+		readyW.Close()
 		return err
+	}
+	// the child has inherited its own copy of the write end; releasing
+	// the parent's copy ensures Read returns EOF if the child dies.
+	readyW.Close()
+
+	if err := waitForReady(readyR, readyTimeout); err != nil {
+		return fmt.Errorf("daemon failed to become ready (see %s): %w", logfile, err)
 	}
 
 	savePID(cmd.Process.Pid)
 	qwm(0, fmt.Sprintf("Process started with PID: %d (logs: %s)", cmd.Process.Pid, logfile))
 
 	return nil
+}
+
+// waitForReady blocks until the child writes to the readiness pipe, the
+// pipe is closed (child exited), or the timeout elapses.
+func waitForReady(r *os.File, timeout time.Duration) error {
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		buf := make([]byte, 1)
+		n, err := r.Read(buf)
+		ch <- result{n: n, err: err}
+	}()
+
+	select {
+	case res := <-ch:
+		if res.n > 0 {
+			return nil
+		}
+		if res.err == nil || res.err == io.EOF {
+			return fmt.Errorf("child exited before signalling readiness")
+		}
+		return res.err
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s", timeout)
+	}
 }
 
 func savePID(pid int) {

--- a/internal/handlers/tracer/helpers.go
+++ b/internal/handlers/tracer/helpers.go
@@ -6,11 +6,48 @@ import (
 	"encoding/binary"
 	"net"
 	"os"
+	"os/user"
+	"runtime"
 	"strconv"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/kondukto-io/kntrl/pkg/logger"
 )
+
+// logRuntimeEnvironment emits a short summary of the kernel/eBPF environment
+// at info level. The intent is to surface prerequisites operators commonly
+// get wrong (cgroup v2 mount, BTF availability, memlock limit, effective
+// uid) in the daemon log before any BPF call has a chance to fail.
+func logRuntimeEnvironment() {
+	logger.Log.Info("kntrl runtime environment:")
+
+	if u, err := user.Current(); err == nil {
+		logger.Log.Infof("  user: %s (uid=%s gid=%s)", u.Username, u.Uid, u.Gid)
+	}
+
+	if data, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil {
+		logger.Log.Infof("  kernel: %s (%s)", strings.TrimSpace(string(data)), runtime.GOARCH)
+	}
+
+	var lim unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_MEMLOCK, &lim); err == nil {
+		logger.Log.Infof("  memlock: cur=%d max=%d", lim.Cur, lim.Max)
+	}
+
+	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err == nil {
+		logger.Log.Info("  cgroup v2: mounted at /sys/fs/cgroup")
+	} else {
+		logger.Log.Warn("  cgroup v2: /sys/fs/cgroup does not look like a unified hierarchy; egress filtering will fail")
+	}
+
+	if _, err := os.Stat("/sys/kernel/btf/vmlinux"); err == nil {
+		logger.Log.Info("  BTF: /sys/kernel/btf/vmlinux available")
+	} else {
+		logger.Log.Warn("  BTF: /sys/kernel/btf/vmlinux missing; CO-RE relocations may fail on older kernels")
+	}
+}
 
 // readyEnvVar names the environment variable through which the daemoniser
 // passes the readiness pipe file descriptor to this process. Kept in sync

--- a/internal/handlers/tracer/helpers.go
+++ b/internal/handlers/tracer/helpers.go
@@ -5,10 +5,43 @@ package tracer
 import (
 	"encoding/binary"
 	"net"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/kondukto-io/kntrl/pkg/logger"
 )
+
+// readyEnvVar names the environment variable through which the daemoniser
+// passes the readiness pipe file descriptor to this process. Kept in sync
+// with cmd/cli's readyEnv.
+const readyEnvVar = "KNTRL_READY_FD"
+
+// signalReady writes a single byte to the readiness pipe inherited from the
+// parent and unsets the env var so child processes don't try to write to the
+// same fd.
+func signalReady() {
+	fdStr := os.Getenv(readyEnvVar)
+	if fdStr == "" {
+		return
+	}
+	os.Unsetenv(readyEnvVar)
+
+	fd, err := strconv.Atoi(fdStr)
+	if err != nil {
+		logger.Log.Warnf("invalid %s value %q: %v", readyEnvVar, fdStr, err)
+		return
+	}
+	f := os.NewFile(uintptr(fd), "ready")
+	if f == nil {
+		logger.Log.Warnf("invalid readiness fd %d", fd)
+		return
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte{1}); err != nil {
+		logger.Log.Warnf("failed to signal readiness on fd %d: %v", fd, err)
+	}
+}
 
 // trimNullBytesLong converts a byte slice to a string, stopping at the first
 // NUL byte. Used to extract C-style strings from fixed-size BPF event fields

--- a/internal/handlers/tracer/tracer.go
+++ b/internal/handlers/tracer/tracer.go
@@ -235,6 +235,10 @@ func Run(cmd cobra.Command) error {
 	// Start async DNS resolution worker for reverse lookups.
 	utils.StartDNSWorker()
 
+	// signal readiness to a daemonising parent now that eBPF programs are
+	// attached and event processing is about to start.
+	signalReady()
+
 	// --- Signal handling ---
 	stopChan := make(chan os.Signal, 1)
 	sighupChan := make(chan os.Signal, 1)

--- a/internal/handlers/tracer/tracer.go
+++ b/internal/handlers/tracer/tracer.go
@@ -117,6 +117,8 @@ func init() {
 func Run(cmd cobra.Command) error {
 	var bundleFS = bundle.Bundle
 
+	logRuntimeEnvironment()
+
 	// --- Configuration loading ---
 	tracerMode, cmddata, dataObj, externalRegoFiles, webhookConfigs, policyCfg, err := loadRunConfig(&cmd)
 	if err != nil {

--- a/internal/handlers/tracer/tracer.go
+++ b/internal/handlers/tracer/tracer.go
@@ -140,6 +140,13 @@ func Run(cmd cobra.Command) error {
 	}
 	cloudClient := initCloudClient(&cmd, policyCfg, rulesFile, rulesDir, ciMeta)
 
+	// Remove memory lock restrictions for eBPF programs. This must happen
+	// before loading any collection on kernels < 5.11, otherwise map
+	// allocation fails with EPERM.
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return err
+	}
+
 	// --- eBPF program loading ---
 	var ebpfClient = ebpfman.New()
 	if err := ebpfClient.Load(prog); err != nil {
@@ -195,11 +202,6 @@ func Run(cmd cobra.Command) error {
 	// Preload established TCP connections so existing sessions (e.g. SSH)
 	// are not disrupted when the egress BPF filter attaches.
 	preloadEstablishedConns(allowedIPMap, allowedIPv6Map)
-
-	// Remove memory lock restrictions for eBPF programs.
-	if err := rlimit.RemoveMemlock(); err != nil {
-		return err
-	}
 
 	// --- Attach eBPF programs to kernel hooks ---
 	cleanups, err := attachPrograms(ebpfClient)

--- a/pkg/ebpf/loader.go
+++ b/pkg/ebpf/loader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
-	"github.com/kondukto-io/kntrl/pkg/logger"
 )
 
 // Load loads the EBPF collection
@@ -17,14 +16,12 @@ func (e *EBPF) Load(collection []byte) error {
 
 	e.Spec, err = ebpf.LoadCollectionSpecFromReader(rd)
 	if err != nil {
-		logger.Log.Fatalf("failed to loading collection spec: %v", err)
-		return fmt.Errorf("failed to loading collection spec: %v", err)
+		return fmt.Errorf("failed to load collection spec: %w", err)
 	}
 
 	e.Collection, err = ebpf.NewCollection(e.Spec)
 	if err != nil {
-		logger.Log.Fatalf("failed to create a new collection: %v", err)
-		return fmt.Errorf("failed to create a new collection: %v", err)
+		return fmt.Errorf("failed to create a new collection: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Whilst trying kntrl out on self-hosted runners I found the daemon would appear to be running fine, but would fail to log any events. Digging into the code, there were a bunch of places that seemed to sends logs to /dev/null and assume the backend tracer was running as long as it briefly started. 

Here’s a series of discrete commits to make this easier to debug things on self-hosted runners 